### PR TITLE
Fix: CategoryModel::create() expects array, not positional args

### DIFF
--- a/Core/McpServer.php
+++ b/Core/McpServer.php
@@ -604,11 +604,11 @@ class McpServer extends Base
                     
                 // Administrative Tools - Category Management
                 case 'create_category':
-                    $categoryId = $this->container['categoryModel']->create(
-                        $arguments['project_id'],
-                        $arguments['name'],
-                        $arguments['description'] ?? ''
-                    );
+                    $categoryId = $this->container['categoryModel']->create([
+                        'project_id' => $arguments['project_id'],
+                        'name' => $arguments['name'],
+                        'description' => $arguments['description'] ?? ''
+                    ]);
                     $result = ['category_id' => $categoryId];
                     break;
                     


### PR DESCRIPTION
## Summary
- `create_category` tool fails with "Failed to parse JSON" on every call
- Root cause: `CategoryModel::create()` expects an associative array (`['project_id' => ..., 'name' => ...]`), but the code passes positional arguments
- This causes a `TypeError` (PHP 7+), which extends `Error`, not `Exception` — so the catch block doesn't handle it, producing a malformed HTTP response
- Fixed by passing an array, consistent with how `create_project` and `create_task` already work

## Test plan
- [ ] Call `create_category` with `project_id` and `name` — should return `category_id`
- [ ] Call `create_category` with optional `description` — should work
- [ ] Verify existing `update_category` and `delete_category` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)